### PR TITLE
Add Maven settings for GitHub CI

### DIFF
--- a/ci/github-settings.xml
+++ b/ci/github-settings.xml
@@ -1,0 +1,22 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo1.maven.org/maven2</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+</settings>


### PR DESCRIPTION
This commit introduces a new Maven settings file specifically for GitHub CI. It configures a GitHub profile and sets the central Maven repository. These settings ensure consistent dependency management during CI builds on GitHub.