### PR TITLE
Fix Dockerfile path in publishing workflows

### DIFF
--- a/.github/workflows/publish-latest-docker-image.yml
+++ b/.github/workflows/publish-latest-docker-image.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           context: .
           push: true
-          file: .github/dockerfile
+          file: .github/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-release-docker-image.yml
+++ b/.github/workflows/publish-release-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           context: .
           push: ${{ github.ref_type == 'tag' }}
-          file: .github/dockerfile
+          file: .github/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Correct the case-sensitive path to the Dockerfile in publish-latest-docker-image.yml and publish-release-docker-image.yml. This ensures the Docker image build process locates the correct file and functions as intended.