### PR TITLE
Add Spring Boot Actuator dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>


### PR DESCRIPTION
Included the Spring Boot Actuator starter in the pom.xml to enable monitoring and management endpoints for the application. This integration will facilitate better observability and operational insight during runtime.